### PR TITLE
Support targets for iOS and Android emulators

### DIFF
--- a/barretenberg/bb_rs/build.rs
+++ b/barretenberg/bb_rs/build.rs
@@ -10,17 +10,46 @@ fn main() {
     // cfg!(target_os = "<os>") does not work so we get the value
     // of the target_os environment variable to determine the target OS.
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target = env::var("TARGET").unwrap();
 
     // Build the C++ code using CMake and get the build directory path.
     let dst;
     // iOS
     if target_os == "ios" {
+        let (platform, arch, cmake_arch, deployment_target, sdk) = if target == "x86_64-apple-ios" {
+            ("SIMULATOR64", "x86_64", "x86_64", "13.0", "iphonesimulator")
+        } else if target == "aarch64-apple-ios-sim" {
+            (
+                "SIMULATORARM64",
+                "arm64",
+                "arm64",
+                "14.0",
+                "iphonesimulator",
+            )
+        } else {
+            ("OS64", "arm64", "arm64", "15.0", "iphoneos")
+        };
+
+        let sdk_path = String::from_utf8(
+            Command::new("xcrun")
+                .args(&["--sdk", sdk, "--show-sdk-path"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
         dst = Config::new("../cpp")
             .generator("Ninja")
             .configure_arg("-DCMAKE_BUILD_TYPE=Release")
-            .configure_arg("-DPLATFORM=OS64")
-            .configure_arg("-DDEPLOYMENT_TARGET=15.0")
-            .configure_arg("--toolchain=../cpp/ios.toolchain.cmake")
+            .configure_arg(&format!("-DPLATFORM={}", platform))
+            .configure_arg(&format!("-DDEPLOYMENT_TARGET={}", deployment_target))
+            .configure_arg(&format!("--toolchain=../cpp/ios.toolchain.cmake"))
+            .define("CMAKE_SYSTEM_NAME", "iOS")
+            .define("CMAKE_OSX_SYSROOT", &sdk_path)
+            .define("CMAKE_OSX_ARCHITECTURES", cmake_arch)
+            .define("CMAKE_SYSTEM_PROCESSOR", arch)
             .build_target("bb")
             .build();
     }
@@ -29,23 +58,58 @@ fn main() {
         let android_home = option_env!("ANDROID_HOME").expect("ANDROID_HOME not set");
         let ndk_version = option_env!("NDK_VERSION").expect("NDK_VERSION not set");
 
+        // Auto-detect host tag
+        let host_tag = env::var("HOST_TAG").unwrap_or_else(|_| {
+            let os = env::consts::OS;
+            match os {
+                "macos" => "darwin-x86_64".to_string(),
+                "linux" => "linux-x86_64".to_string(),
+                "windows" => "windows-x86_64".to_string(),
+                _ => panic!("Unsupported host OS: {}", os),
+            }
+        });
+
+        // Map Rust target to Android ABI
+        let android_abi = match target.as_str() {
+            "x86_64-linux-android" => "x86_64",
+            "aarch64-linux-android" => "arm64-v8a",
+            "armv7-linux-androideabi" => "armeabi-v7a",
+            _ => panic!("Unsupported Android target: {}", target),
+        };
+
+        // Set up compiler paths
+        let ndk_path = format!("{}/ndk/{}", android_home, ndk_version);
+        let toolchain_path = format!("{}/toolchains/llvm/prebuilt/{}", ndk_path, host_tag);
+
+        // Set environment variables for the cmake crate
+        env::set_var("CC", format!("{}/bin/{}26-clang", toolchain_path, target));
+        env::set_var(
+            "CXX",
+            format!("{}/bin/{}26-clang++", toolchain_path, target),
+        );
+        env::set_var("AR", format!("{}/bin/llvm-ar", toolchain_path));
+        env::set_var("RANLIB", format!("{}/bin/llvm-ranlib", toolchain_path));
+
         dst = Config::new("../cpp")
-        .generator("Ninja")
-        .configure_arg("-DCMAKE_BUILD_TYPE=Release")
-        .configure_arg("-DANDROID_ABI=arm64-v8a")
-        .configure_arg("-DANDROID_PLATFORM=android-33")
-        .configure_arg(&format!("--toolchain={}/ndk/{}/build/cmake/android.toolchain.cmake", android_home, ndk_version))
-        .build_target("bb")
-        .build();
+            .generator("Ninja")
+            .configure_arg("-DCMAKE_BUILD_TYPE=Release")
+            .configure_arg(&format!("-DANDROID_ABI={}", android_abi))
+            .configure_arg("-DANDROID_PLATFORM=android-33")
+            .configure_arg(&format!(
+                "-DCMAKE_TOOLCHAIN_FILE={}/build/cmake/android.toolchain.cmake",
+                ndk_path
+            ))
+            .build_target("bb")
+            .build();
     }
     // MacOS and other platforms
     else {
         dst = Config::new("../cpp")
-        .generator("Ninja")
-        .configure_arg("-DCMAKE_BUILD_TYPE=Release")            
-        .configure_arg("-DTRACY_ENABLE=OFF")
-        .build_target("bb")
-        .build();
+            .generator("Ninja")
+            .configure_arg("-DCMAKE_BUILD_TYPE=Release")
+            .configure_arg("-DTRACY_ENABLE=OFF")
+            .build_target("bb")
+            .build();
     }
 
     // Add the library search path for Rust to find during linking.
@@ -63,7 +127,13 @@ fn main() {
 
     // Copy the headers to the build directory.
     // Fix an issue where the headers are not included in the build.
-    Command::new("sh").args(&["copy-headers.sh", &format!("{}/build/include", dst.display())]).output().unwrap();
+    Command::new("sh")
+        .args(&[
+            "copy-headers.sh",
+            &format!("{}/build/include", dst.display()),
+        ])
+        .output()
+        .unwrap();
 
     let mut builder = bindgen::Builder::default();
 
@@ -72,26 +142,79 @@ fn main() {
         let ndk_version = option_env!("NDK_VERSION").expect("NDK_VERSION not set");
         let host_tag = option_env!("HOST_TAG").expect("HOST_TAG not set");
 
+        // Determine the target-specific include path
+        let target_include = match target.as_str() {
+            "x86_64-linux-android" => "x86_64-linux-android",
+            "aarch64-linux-android" => "aarch64-linux-android",
+            "armv7-linux-androideabi" => "arm-linux-androideabi",
+            _ => panic!("Unsupported Android target: {}", target),
+        };
+
         builder = builder
-        // Add the include path for headers.
-        .clang_args([
-            "-std=c++20",
-            "-xc++",
-            &format!("-I{}/build/include", dst.display()),
-            &format!("-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include/c++/v1", android_home, ndk_version, host_tag),
-            &format!("-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include", android_home, ndk_version, host_tag),
-            &format!("-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include/aarch64-linux-android", android_home, ndk_version, host_tag)
-        ]);
+            // Add the include path for headers.
+            .clang_args([
+                "-std=c++20",
+                "-xc++",
+                &format!("-I{}/build/include", dst.display()),
+                &format!(
+                    "-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include/c++/v1",
+                    android_home, ndk_version, host_tag
+                ),
+                &format!(
+                    "-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include",
+                    android_home, ndk_version, host_tag
+                ),
+                &format!(
+                    "-I{}/ndk/{}/toolchains/llvm/prebuilt/{}/sysroot/usr/include/{}",
+                    android_home, ndk_version, host_tag, target_include
+                ),
+            ]);
     } else if target_os == "ios" {
+        // check which SDK we need
+        let sdk = if target.contains("sim") || target.contains("x86_64") {
+            "iphonesimulator"
+        } else {
+            "iphoneos"
+        };
+        let sdk_path = String::from_utf8(
+            Command::new("xcrun")
+                .args(&["--sdk", sdk, "--show-sdk-path"])
+                .output()
+                .expect("failed to get SDK path for iOS")
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        // Build clang args based on target
+        let mut clang_args = vec![
+            "-std=c++20".to_string(),
+            "-xc++".to_string(),
+            format!("-I{}/build/include", dst.display()),
+            "-isysroot".to_string(),
+            sdk_path.clone(),
+            "-target".to_string(),
+            target.clone(),
+        ];
+
+        // Add minimum version based on target
+        if target == "x86_64-apple-ios" {
+            clang_args.push("-mios-simulator-version-min=13.0".to_string());
+        } else if target == "aarch64-apple-ios-sim" {
+            clang_args.push("-mios-simulator-version-min=14.0".to_string());
+        } else if target == "aarch64-apple-ios" {
+            clang_args.push("-miphoneos-version-min=15.0".to_string());
+        }
+
+        // Add include paths
+        clang_args.push(format!("-I{}/usr/include/c++/v1", sdk_path));
+        clang_args.push(format!("-I{}/usr/include", sdk_path));
+
         builder = builder
-        // Add the include path for headers.
-        .clang_args([
-            "-std=c++20",
-            "-xc++",
-            &format!("-I{}/build/include", dst.display()),
-            "-I/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/c++/v1",
-            "-I/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include"
-        ]);
+            .clang_args(&clang_args)
+            // Ensure we're using the correct clang
+            .clang_arg(&format!("--sysroot={}", sdk_path));
     } else if target_os == "macos" {
         builder = builder
             // Add the include path for headers.
@@ -104,12 +227,12 @@ fn main() {
             ]);
     } else {
         builder = builder
-        // Add the include path for headers.
-        .clang_args([
-            "-std=c++20",
-            "-xc++",
-            &format!("-I{}/build/include", dst.display())
-        ]);
+            // Add the include path for headers.
+            .clang_args([
+                "-std=c++20",
+                "-xc++",
+                &format!("-I{}/build/include", dst.display()),
+            ]);
     }
 
     let bindings = builder

--- a/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
@@ -4,7 +4,12 @@
 #include <cstring>
 #include <functional>
 #include <random>
-#include <sys/random.h>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <stdlib.h> // arc4random_buf
+#else
+#include <sys/random.h> // Linux
+#endif
 
 namespace bb::numeric {
 
@@ -51,11 +56,14 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
         uint8_t* current_offset = random_buffer_wrapper.buffer;
         // Sample until we fill the buffer
         while (bytes_left != 0) {
-#if defined(__wasm__) || defined(__APPLE__)
-            // Sample through a "syscall" on wasm. We can't request more than 256, it fails and results in an infinite
-            // loop
+#if defined(__wasm__) || (defined(__APPLE__) && TARGET_OS_OSX)
+            // using getentropy on MacOS
             ssize_t read_bytes =
                 getentropy(current_offset, BYTES_PER_GETENTROPY_READ) == -1 ? -1 : BYTES_PER_GETENTROPY_READ;
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+            //  using arc4random_buf on iOS
+            arc4random_buf(current_offset, BYTES_PER_GETENTROPY_READ);
+            ssize_t read_bytes = BYTES_PER_GETENTROPY_READ
 #else
             // Sample from urandom on native
             auto read_bytes = getrandom(current_offset, bytes_left, 0);


### PR DESCRIPTION
this PR mirrors Kimi's PR for supporting targets for iOS and Android emulator
- https://github.com/KimiWu123/aztec-packages/pull/1

specifically,
- iOS
  - `aarch64-apple-ios`
  - `aarch64-apple-ios-sim`
  - `x86_64-apple-ios`
- Android
  - `aarch64-linux-android`
  - `x86_64-linux-android`
